### PR TITLE
Fix iterator expiry test

### DIFF
--- a/test/khash_test.erl
+++ b/test/khash_test.erl
@@ -240,7 +240,7 @@ no_expiration_iterators_test_() ->
                     }
                 end,
                 fun({ok, H, I, Err}) ->
-                    {ok, I} = khash:iter(H),
+                    {ok, _OtherI} = khash:iter(H),
                     {foo, bar} = khash:iter_next(I),
                     end_of_table = khash:iter_next(I),
                     {


### PR DESCRIPTION
This test started failing with Erlang 20.0 release. The reason is that opaaque
NIF resources stopped being identifed as empty binaries in Erlang so previously
it matched but once refs were used it stopped matching.

Fixes #855