### PR TITLE
Handle deprecated random module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,3 @@ help:
 	@egrep "^# target:" Makefile | sed -e 's/^# target: //g' | sort
 
 
-%.beam: %.erl
-	erlc -o test/ $<

--- a/rebar.config
+++ b/rebar.config
@@ -11,3 +11,12 @@
     {"win32", "CFLAGS", "$CFLAGS /O2 /DNDEBUG /Wall"}
 ]}.
 
+{erl_opts, [
+   {platform_define, "^R16", 'NORANDMODULE'},
+   {platform_define, "^17", 'NORANDMODULE'}
+]}.
+
+{eunit_compile_opts, [
+   {platform_define, "^R16", 'NORANDMODULE'},
+   {platform_define, "^17", 'NORANDMODULE'}
+]}.

--- a/test/gen_term.erl
+++ b/test/gen_term.erl
@@ -42,18 +42,18 @@ gen_atom(MaxSize) ->
 
 
 gen_integer(_) ->
-    Value = case random_uniform() < 0.5 of
-        true -> random_uniform(127);
-        false -> random_uniform(16#FFFFFFFF)
+    Value = case khash_rand:uniform() < 0.5 of
+        true -> khash_rand:uniform(127);
+        false -> khash_rand:uniform(16#FFFFFFFF)
     end,
-    case random_uniform() < 0.5 of
+    case khash_rand:uniform() < 0.5 of
         true -> -1 * Value;
         false -> Value
     end.
 
 
 gen_float(_) ->
-    random_uniform() * float(16#FFFFFFFF).
+    khash_rand:uniform() * float(16#FFFFFFFF).
 
 
 gen_reference(_) ->
@@ -62,12 +62,12 @@ gen_reference(_) ->
 
 gen_port(_) ->
     Ports = erlang:ports(),
-    lists:nth(random_uniform(length(Ports)), Ports).
+    lists:nth(khash_rand:uniform(length(Ports)), Ports).
 
 
 gen_pid(_) ->
     Pids = erlang:processes(),
-    lists:nth(random_uniform(length(Pids)), Pids).
+    lists:nth(khash_rand:uniform(length(Pids)), Pids).
 
 
 gen_tuple(MaxSize) ->
@@ -75,18 +75,18 @@ gen_tuple(MaxSize) ->
 
 
 gen_list(MaxSize) ->
-    Width = random_uniform(MaxSize),
+    Width = khash_rand:uniform(MaxSize),
     [any(MaxSize-Width) || _ <- lists:seq(1, Width)].
 
 
 gen_short_string(_) ->
-    Size = random_uniform(255),
-    [random_uniform(127) || _ <- lists:seq(1, Size)].
+    Size = khash_rand:uniform(255),
+    [khash_rand:uniform(127) || _ <- lists:seq(1, Size)].
 
 
 gen_string(_) ->
-    Size = random_uniform(4096),
-    [random_uniform(127) || _ <- lists:seq(1, Size)].
+    Size = khash_rand:uniform(4096),
+    [khash_rand:uniform(127) || _ <- lists:seq(1, Size)].
 
 
 gen_binary(MaxSize) ->
@@ -99,7 +99,7 @@ gen_bitstring(MaxSize) ->
 
 
 gen_bignum(_) ->
-    16#FFFFFFFFFFFFFFFF + random_uniform(16#FFFFFFFF).
+    16#FFFFFFFFFFFFFFFF + khash_rand:uniform(16#FFFFFFFF).
 
 
 gen_function(_) ->
@@ -107,7 +107,7 @@ gen_function(_) ->
 
 
 choice(Options) ->
-    lists:nth(random_uniform(length(Options)), Options).
+    lists:nth(khash_rand:uniform(length(Options)), Options).
 
 
 value_types() ->
@@ -129,12 +129,3 @@ value_types() ->
 
 all_types() ->
     value_types() ++ [gen_tuple, gen_list].
-
-
-random_uniform() ->
-    Range = 1 bsl 32,
-    crypto:rand_uniform(0, Range) / Range.
-
-
-random_uniform(N) ->
-    crypto:rand_uniform(1, N + 1).

--- a/test/khash_rand.erl
+++ b/test/khash_rand.erl
@@ -1,0 +1,57 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(khash_rand).
+
+
+-export([
+    uniform/0,
+    uniform/1
+]).
+
+
+-ifdef(NORANDMODULE).
+
+
+uniform() ->
+    maybe_set_random_seed(),
+    random:uniform().
+
+
+uniform(N) ->
+    maybe_set_random_seed(),
+    random:uniform(N).
+
+
+maybe_set_random_seed() ->
+    case get(random_seed) of
+        undefined ->
+            {_, Sec, USec} = os:timestamp(),
+            Seed = {erlang:phash2(self()), Sec, USec},
+            random:seed(Seed);
+        _ ->
+            ok
+    end.
+
+
+-else.
+
+
+uniform() ->
+    rand:uniform().
+
+
+uniform(N) ->
+    rand:uniform(N).
+
+
+-endif.

--- a/test/khash_test.erl
+++ b/test/khash_test.erl
@@ -366,7 +366,7 @@ run_to_list({D, H}) ->
 weighted_choice(Items0) ->
     Items = lists:sort(Items0),
     Sum = lists:sum([W || {W, _} <- Items]),
-    Choice = random_uniform() * Sum,
+    Choice = khash_rand:uniform() * Sum,
     weighted_choice(Items, 0.0, Choice).
 
 weighted_choice([], _, _) ->
@@ -378,16 +378,7 @@ weighted_choice([{_, I} | _], _, _) ->
 
 random_key(D) ->
     Keys = lists:usort(dict:fetch_keys(D) ++ [foo]),
-    lists:nth(random_uniform(length(Keys)), Keys).
+    lists:nth(khash_rand:uniform(length(Keys)), Keys).
 
 random_val() ->
     gen_term:any().
-
-
-random_uniform() ->
-    Range = 1 bsl 32,
-    crypto:rand_uniform(0, Range) / Range.
-
-
-random_uniform(N) ->
-    crypto:rand_uniform(1, N + 1).


### PR DESCRIPTION
Use a compile time check for platform versions, then a macro conditional in a
separate rand module.

Removed redunant beam file compile rule from Makefile as it prevented erl_opts
rebar options form taking effect.